### PR TITLE
skip invalid seek offset

### DIFF
--- a/symphonia-format-mkv/src/demuxer.rs
+++ b/symphonia-format-mkv/src/demuxer.rs
@@ -345,7 +345,14 @@ impl FormatReader for MkvReader {
                             Some((_, etype)) => *etype,
                             None => continue,
                         };
-                        seek_positions.push((etype, segment_pos + element.position));
+                        let destination = match segment_pos.checked_add(element.position) {
+                            Some(pos) => pos,
+                            None => {
+                                println!("seek position overflow for {:?}", etype);
+                                continue;
+                            }
+                        };
+                        seek_positions.push((etype, destination));
                     }
                 }
                 ElementType::Tracks => {


### PR DESCRIPTION
We came across content where the "+" would fail with overflow. This is a first potential fix to be tested more for the possible implications